### PR TITLE
Sort order

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -27,8 +27,12 @@ func (c ConvertFunc) Convert(val string) (i interface{}, err error) {
 
 // Primitives gives access to the RegEx and ObjectID convertors.
 type Primitives interface {
+	// RegEx converts pattern and options to bson.Regex.
 	RegEx(pattern, options string) (rx interface{}, err error)
+	// ObjectID converts val to bson.ObjectID.
 	ObjectID(val string) (oid interface{}, err error)
+	// DocElem converts key and val o bson.DocElem, which is a bson.D element.
+	DocElem(key string, val interface{}) (d interface{}, err error)
 }
 
 // String returns a string val.

--- a/convert_test.go
+++ b/convert_test.go
@@ -28,7 +28,9 @@ type testRegEx struct {
 	regex, options string
 }
 
-type testOidPrimitive struct{}
+type testOidPrimitive struct {
+	forbidSortFields map[string]struct{}
+}
 
 func (t testOidPrimitive) RegEx(v, o string) (i interface{}, err error) {
 	return testRegEx{regex: v, options: o}, nil
@@ -36,6 +38,17 @@ func (t testOidPrimitive) RegEx(v, o string) (i interface{}, err error) {
 
 func (t testOidPrimitive) ObjectID(val string) (i interface{}, err error) {
 	return testObjectID{oid: val}, nil
+}
+
+func (t testOidPrimitive) DocElem(key string, val interface{}) (
+	kv interface{}, err error) {
+	if t.forbidSortFields != nil {
+		if _, forbid := t.forbidSortFields[key]; forbid {
+			return nil, ErrNoSortField
+		}
+	}
+
+	return map[string]interface{}{key: val}, nil
 }
 
 //nolint:paralleltest


### PR DESCRIPTION
 Fix problem with sort order. This problem may appear when an operator
 `__sort` contains an array. i.e. `?__sort=a,b`.

 Since the problem appears due to the `map` usage which does not have
 keys order guarantee we needed to replace `map` with a slice.

 Changed `Query.Sort` field type from `map` to `interface{}`.

 Added `DocElem()` function to `Primitives` interface.

 Changed `Query.AddSort()` function.

 Added operator validation to `Parser.convert()` function.

 Fixed panic on `Parser.Parse()` when either `Parser.Converter` field is `nil` or
 `Parser.Converter.Primitives` field is nil. `Parser.Parse()` returns an
 `error` instead.

 Added some documentation to README.md.